### PR TITLE
linux datadir fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ _This wallet has no connection to the original **electrum** wallet, it is exclus
 
 MacOS: `~/Library/Application Support/VERGE`
 Windows: `%appdata%/VERGE`
-Linux: `~/VERGE`
+Linux: `~/.VERGE`
 
 ```conf
 rpcuser=mylocaluser # your connection password


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
just fixes the linux datadir for verge, by adding a period

## Motivation and Context
might confuse new linux users
