### PR TITLE
Remove OS focus highlight

### DIFF
--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -20,6 +20,10 @@ body {
   font-family: 'AvenirNextLTW01Regular', Helvetica, sans-serif !important;
 }
 
+a:hover {
+  text-decoration: none;
+}
+
 .logo {
   content: url('../images/verge-logo-white.png');
 }
@@ -208,7 +212,7 @@ input,
 button,
 textarea,
 :focus {
-  outline: none; // You should add some other style for :focus to help UX/a11y
+  outline: none !important; // You should add some other style for :focus to help UX/a11y
 }
 
 input[type='number']::-webkit-inner-spin-button,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
-import './assets/css/main.scss'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import './assets/css/main.scss'
 
 import * as React from 'react'
 


### PR DESCRIPTION
On my mac every button and link did have a ugly OS highlighting around it.
Which didn't support the UX.

Also all a elements got an underline when hovering which didn't support the UX either.

Lastly I changed the order of the custom css with bootstrap.
So we don't have to tell what's important all the time.

## Motivation and Context
Improve UX

## Screenshots (if appropriate):
<img width="246" alt="active" src="https://user-images.githubusercontent.com/3099122/41893076-c5cb6f9a-791a-11e8-8ba8-422cc6c294ff.png">
<img width="219" alt="hover" src="https://user-images.githubusercontent.com/3099122/41893078-c7583f78-791a-11e8-936c-30253f438fb7.png">


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
