### PR TITLE
No donations when zero balance or wallet locked

### DIFF
--- a/src/assets/css/donate-modal.scss
+++ b/src/assets/css/donate-modal.scss
@@ -1,3 +1,7 @@
+.donate-modal > div.modal-content > div.modal-body {
+  min-height: 545px;
+}
+
 .donate-modal .donate-description {
   font-weight: 400;
   font-size: 14px;

--- a/src/assets/css/main.scss
+++ b/src/assets/css/main.scss
@@ -28,6 +28,7 @@
 
 @import 'send-modal';
 @import 'receive-modal';
+@import 'no-balance-panel';
 @import 'debug-information-modal';
 @import 'donate-modal';
 

--- a/src/assets/css/no-balance-panel.scss
+++ b/src/assets/css/no-balance-panel.scss
@@ -1,0 +1,22 @@
+.no-balance-modal > div.modal-content > div.modal-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.no-balance-modal > div.modal-content > div.modal-body > p {
+  margin-bottom: 0;
+}
+
+.no-balance-title {
+  color: #b0c1c8;
+  font-weight: 500;
+  font-size: 26px;
+}
+
+.no-balance-subtitle {
+  color: #cbd9df;
+  font-size: 15px;
+  text-align: center;
+}

--- a/src/assets/css/send-modal.scss
+++ b/src/assets/css/send-modal.scss
@@ -2,29 +2,6 @@
   min-height: 518px;
 }
 
-.send-modal.send-modal-balance-to-low > div.modal-content > div.modal-body {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.send-modal.send-modal-balance-to-low > div.modal-content > div.modal-body > p {
-  margin-bottom: 0;
-}
-
-.no-balance-title {
-  color: #b0c1c8;
-  font-weight: 500;
-  font-size: 26px;
-}
-
-.no-balance-subtitle {
-  color: #cbd9df;
-  font-size: 15px;
-  text-align: center;
-}
-
 .balance-title {
   color: #476b84;
   font-size: 6px;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,8 +4,10 @@ import { inject, observer } from 'mobx-react'
 
 import CreditsPanel from './modal/CreditsPanel'
 import { SettingsStore } from '../stores/SettingsStore'
+import { AccountInformationStore } from '../stores/AccountInformationStore'
 import { shell } from 'electron'
 import { translate, Trans } from 'react-i18next'
+import { Tooltip } from 'reactstrap'
 import styledComponents from 'styled-components'
 import DebugPanel from './modal/DebugPanel'
 import DonatePanel from './modal/DonatePanel'
@@ -21,12 +23,14 @@ const FooterVersion = styledComponents.div`
 
 interface FooterProps {
   SettingsStore?: SettingsStore
+  AccountInformationStore?: AccountInformationStore
 }
 
 interface FooterState {
   credits: boolean
   debugWindow: boolean
   donateModal: boolean
+  tooltipDonateOpen: boolean
 }
 
 class Footer extends React.Component<FooterProps, FooterState> {
@@ -36,6 +40,7 @@ class Footer extends React.Component<FooterProps, FooterState> {
       credits: false,
       debugWindow: false,
       donateModal: false,
+      tooltipDonateOpen: false,
     }
 
     this.toggle = this.toggle.bind(this)
@@ -50,7 +55,17 @@ class Footer extends React.Component<FooterProps, FooterState> {
   }
 
   toggleDonate(item: 'donateModal' = 'donateModal') {
-    return () => this.setState({ [item]: !this.state[item] })
+    return () => {
+      if (this.props.AccountInformationStore!.unlocked) {
+        this.setState({ [item]: !this.state[item] })
+      }
+    }
+  }
+
+  toggleDonateTooltip() {
+    this.setState({
+      tooltipDonateOpen: !this.state.tooltipDonateOpen,
+    })
   }
 
   openLatestRelease() {
@@ -91,7 +106,18 @@ class Footer extends React.Component<FooterProps, FooterState> {
           >
             <Trans i18nKey={'footer.debug_information'} />
           </FooterText>
+          {!this.props.AccountInformationStore!.unlocked &&
+            <Tooltip
+              placement="top"
+              target="donate-xvg"
+              isOpen={this.state.tooltipDonateOpen}
+              toggle={this.toggleDonateTooltip.bind(this)}
+            >
+              <Trans i18nKey={'unlock.title'} />
+            </Tooltip>
+          }
           <FooterText
+            id="donate-xvg"
             className="col-md-1 text-right clicky"
             onClick={this.toggleDonate('donateModal')}
           >
@@ -109,4 +135,4 @@ class Footer extends React.Component<FooterProps, FooterState> {
   }
 }
 
-export default translate()(inject('SettingsStore')(observer(Footer)))
+export default translate()(inject('SettingsStore', 'AccountInformationStore')(observer(Footer)))

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -106,7 +106,7 @@ class Footer extends React.Component<FooterProps, FooterState> {
           >
             <Trans i18nKey={'footer.debug_information'} />
           </FooterText>
-          {!this.props.AccountInformationStore!.unlocked &&
+          {!this.props.AccountInformationStore!.unlocked && (
             <Tooltip
               placement="top"
               target="donate-xvg"
@@ -115,7 +115,7 @@ class Footer extends React.Component<FooterProps, FooterState> {
             >
               <Trans i18nKey={'unlock.title'} />
             </Tooltip>
-          }
+          )}
           <FooterText
             id="donate-xvg"
             className="col-md-1 text-right clicky"
@@ -135,4 +135,6 @@ class Footer extends React.Component<FooterProps, FooterState> {
   }
 }
 
-export default translate()(inject('SettingsStore', 'AccountInformationStore')(observer(Footer)))
+export default translate()(
+  inject('SettingsStore', 'AccountInformationStore')(observer(Footer)),
+)

--- a/src/components/modal/DebugPanel.tsx
+++ b/src/components/modal/DebugPanel.tsx
@@ -82,7 +82,7 @@ class DebugPanel extends React.Component<{
               type,
             ).map(({ key, value }) => {
               return value ? (
-                <div className="debug-information-row">
+                <div className="debug-information-row" key={key}>
                   <div className="debug-information-row-title">
                     <Trans i18nKey={`debug.${key}`} />
                   </div>
@@ -91,7 +91,7 @@ class DebugPanel extends React.Component<{
               ) : null
             })
             return (
-              <div className="debug-information-section">
+              <div className="debug-information-section" key={type}>
                 <div className="debug-information-section-title">
                   <div className="debug-information-section-title-icon">
                     {this.mapCategoryToIcon(type)}

--- a/src/components/modal/DonatePanel.tsx
+++ b/src/components/modal/DonatePanel.tsx
@@ -4,6 +4,7 @@ import SendState from '../../utils/SendState'
 import AmountInput from '../transaction/AmountInput'
 import BalanceBar from '../transaction/BalanceBar'
 import SendTransactionButton from '../transaction/SendTransactionButton'
+import NoBalancePanel from './NoBalancePanel'
 import GiftIcon from 'react-material-icon-svg/dist/GiftIcon'
 import { inject, observer } from 'mobx-react'
 import { translate, Trans } from 'react-i18next'
@@ -11,6 +12,7 @@ import { CoinStatsStore } from '../../stores/CoinStatsStore'
 import { AccountInformationStore } from '../../stores/AccountInformationStore'
 import { SettingsStore } from '../../stores/SettingsStore'
 import { i18n } from 'i18next'
+import Fee from '../../utils/Fee'
 
 const XVG_DONATION_ADDRESS = 'D7KV88Zg2XNHUtX1DYhMsoHRz1RG9xGSmM'
 
@@ -46,6 +48,10 @@ class DonatePanel extends React.Component<DonatePanelInterface, DonatePanelState
 
   amountChanged(amount) {
     this.setState({ amount })
+  }
+
+  balanceToLow() {
+    return (this.props.AccountInformationStore!.getBalance - Fee) <= 0
   }
 
   sendTransaction() {
@@ -85,6 +91,16 @@ class DonatePanel extends React.Component<DonatePanelInterface, DonatePanelState
   }
 
   render() {
+    if (this.balanceToLow()) {
+      return (
+        <NoBalancePanel
+          {...this.props}
+          title={this.props.i18n!.t('donatePanel.title') as string}
+          className="donate-modal"
+        />
+      )
+    }
+
     return (
       <Modal
         {...this.props}

--- a/src/components/modal/NoBalancePanel.tsx
+++ b/src/components/modal/NoBalancePanel.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+import ScaleBalanceIcon from 'react-material-icon-svg/dist/ScaleBalanceIcon'
+import { i18n } from 'i18next'
+import { observer } from 'mobx-react'
+import { translate } from 'react-i18next'
+
+interface NoBalancePanelProps {
+  title: string
+  open: boolean
+  toggle: (() => void) & ((event: Event) => void)
+  className: string
+  i18n?: i18n
+}
+
+import Modal from '../Modal'
+
+class NoBalancePanel extends React.Component<NoBalancePanelProps> {
+  render() {
+    return (
+      <Modal
+        {...this.props}
+        title={this.props.title}
+        className={`no-balance-modal ${this.props.className}`}
+      >
+        <ScaleBalanceIcon
+          width={100}
+          height={100}
+          fill="#d6dee2"
+        />
+        <p className="no-balance-title">{this.props.i18n!.t('sendPanel.notEnoughBalance')}</p>
+        <p className="no-balance-subtitle">
+          {this.props.i18n!.t('sendPanel.notEnoughBalanceDescription')}
+        </p>
+      </Modal>
+    )
+  }
+}
+
+export default translate()(
+  observer(NoBalancePanel),
+)

--- a/src/components/modal/SendPanel.tsx
+++ b/src/components/modal/SendPanel.tsx
@@ -3,9 +3,9 @@ import { inject, observer } from 'mobx-react'
 import Modal from '../Modal'
 import AmountInput from '../transaction/AmountInput'
 import BalanceBar from '../transaction/BalanceBar'
+import NoBalancePanel from './NoBalancePanel'
 import SendTransactionButton from '../transaction/SendTransactionButton'
 import SendIcon from 'react-material-icon-svg/dist/SendIcon'
-import ScaleBalanceIcon from 'react-material-icon-svg/dist/ScaleBalanceIcon'
 import * as React from 'react'
 import { translate, Trans } from 'react-i18next'
 import { AccountInformationStore } from '../../stores/AccountInformationStore'
@@ -107,21 +107,11 @@ class SendPanel extends React.Component<SendPanelProps, SendPanelState> {
 
     if (this.balanceToLow()) {
       return (
-        <Modal
+        <NoBalancePanel
           {...props}
           title={this.props.i18n!.t('sendPanel.title') as string}
-          className="send-modal send-modal-balance-to-low"
-        >
-          <ScaleBalanceIcon
-            width={100}
-            height={100}
-            fill="#d6dee2"
-          />
-          <p className="no-balance-title">{this.props.i18n!.t('sendPanel.notEnoughBalance')}</p>
-          <p className="no-balance-subtitle">
-            {this.props.i18n!.t('sendPanel.notEnoughBalanceDescription')}
-          </p>
-        </Modal>
+          className="send-modal"
+        />
       )
     }
 


### PR DESCRIPTION
No donations when zero balance or wallet locked.

The `unlock your wallet` tooltip has been added to the donation button in the footer.
Also the balance too low modal has been abstracted into it's own component and then used for the donate modal as well 💯 